### PR TITLE
Swift 3 support and Optional("Message") bug 

### DIFF
--- a/GLNotificationBar/Classes/GLNotificationBar.swift
+++ b/GLNotificationBar/Classes/GLNotificationBar.swift
@@ -241,7 +241,7 @@ open class GLNotificationBar: NSObject {
             break
         }
         
-        let attributeString = NSMutableAttributedString(string: String("\(header)\n\(body)"))
+        let attributeString = NSMutableAttributedString(string: String("\(header ?? "")\n\(body ?? "")"))
         attributeString.addAttributes([NSFontAttributeName:UIFont.boldSystemFont(ofSize: 15)], range: NSRange(location: 0, length: header.characters.count))
         notificationBar.body.attributedText = attributeString
         

--- a/GLNotificationBar/Classes/GLNotificationBar.swift
+++ b/GLNotificationBar/Classes/GLNotificationBar.swift
@@ -5,9 +5,28 @@
 //  Created by gokul on 17/10/16.
 //  Copyright (c) 2016 gokul. All rights reserved.
 //
-
 import UIKit
 import AVFoundation
+fileprivate func < <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+    switch (lhs, rhs) {
+    case let (l?, r?):
+        return l < r
+    case (nil, _?):
+        return true
+    default:
+        return false
+    }
+}
+
+fileprivate func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
+    switch (lhs, rhs) {
+    case let (l?, r?):
+        return l > r
+    default:
+        return rhs < lhs
+    }
+}
+
 
 /**
  Notification action types.
@@ -19,15 +38,15 @@ import AVFoundation
  */
 @objc public enum GLNotificationActionType:Int {
     ///Default: Apply the default style to the action’s button.
-    case Default = 0
+    case `default` = 0
     ///Destructive: Apply a style that indicates the action might change or delete data.
-    case Destructive
+    case destructive
     ///TextInput: Apply a style that indicates the action opens an textinput field helps to respond notification as string.
-    case TextInput
+    case textInput
     ///OnlyTextInput: Apply a style which removes all other action added and simply adds text field as input to respond notification.
-    case OnlyTextInput
+    case onlyTextInput
     ///Cancel: Apply a style that indicates the action cancels the operation and leaves things unchanged.
-    case Cancel
+    case cancel
 }
 
 /**
@@ -37,19 +56,19 @@ import AVFoundation
  */
 @objc public enum GLNotificationStyle:Int {
     ///SimpleBanner: Apply the SimpleBanner style that displays notification as simple banner,it can't open in detail by swiping down.
-    case SimpleBanner = 0
+    case simpleBanner = 0
     ///DetailedBanner: Apply a style that opens message in detail with `GLNotifyAction` if added.
-    case DetailedBanner
+    case detailedBanner
 }
 
 enum PanDirection:Int {
-    case Up = -1
-    case Down = 1
+    case up = -1
+    case down = 1
 }
 
 enum DeviceOrientation {
-    case Portrait
-    case Landscape
+    case portrait
+    case landscape
 }
 /// Default height of `GLNotificationBar` is 100
 let BAR_HEIGHT:CGFloat = 100
@@ -58,8 +77,8 @@ let BAR_HEIGHT:CGFloat = 100
 var SHOW_TIME:Double = 5
 
 
-let APP_DELEGATE = UIApplication.sharedApplication()
-let frameWidth:CGFloat! = UIApplication.sharedApplication().keyWindow?.bounds.width
+let APP_DELEGATE = UIApplication.shared
+let frameWidth:CGFloat! = UIApplication.shared.keyWindow?.bounds.width
 
 var appIconName:String!
 var appName:String!
@@ -68,20 +87,19 @@ var notificationBar:CustomView!
 var audioPlayer = AVAudioPlayer()
 var actionArray = [GLNotifyAction]()
 
-var block: dispatch_block_t?
-var timer:NSTimer?
+var timer:Timer?
 
 
-var messageDidSelect:(Bool -> Void)!
+var messageDidSelect:((Bool) -> Void)!
 
 /**
-   A GLNotificationBar object displays an banner message to user (**iOS 10 Style**) over top of the screen which helps to handle local or remote notification when app is in active state. 
+ A GLNotificationBar object displays an banner message to user (**iOS 10 Style**) over top of the screen which helps to handle local or remote notification when app is in active state.
  
-   Can add `GLNotifyAction` as action to the message, which provides `button or text input` fields to respond to notification.
+ Can add `GLNotifyAction` as action to the message, which provides `button or text input` fields to respond to notification.
  
  */
-public class GLNotificationBar: NSObject {
-
+open class GLNotificationBar: NSObject {
+    
     @objc public override init() {
         super.init()
     }
@@ -107,27 +125,27 @@ public class GLNotificationBar: NSObject {
         actionArray = [GLNotifyAction]()
         messageDidSelect = handler
         if ((APP_DELEGATE.keyWindow?.subviews) == nil) {
-            let time = dispatch_time(DISPATCH_TIME_NOW, Int64(5.0 * Double(NSEC_PER_SEC)))
-            dispatch_after(time, dispatch_get_main_queue(), {
+            let time = DispatchTime.now() + Double(Int64(5.0 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
+            DispatchQueue.main.asyncAfter(deadline: time, execute: {
                 self.setUpNotificationBar(title, body: message , notificationStyle:preferredStyle)
             })
         }else{
             setUpNotificationBar(title, body: message , notificationStyle:preferredStyle)
         }
-
         
-         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(1.0 * Double(NSEC_PER_SEC) )), dispatch_get_main_queue()) {
+        
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(1.0 * Double(NSEC_PER_SEC) )) / Double(NSEC_PER_SEC)) {
             if SHOW_TIME != 0 {
                 if (timer != nil) {
                     timer!.invalidate()
                 }
-                timer = NSTimer.scheduledTimerWithTimeInterval(SHOW_TIME - 1.0, target: self, selector: #selector(self.hideNotification(_:)), userInfo: nil, repeats: false
+                timer = Timer.scheduledTimer(timeInterval: SHOW_TIME - 1.0, target: self, selector: #selector(self.hideNotification(_:)), userInfo: nil, repeats: false
                 )
             }
         }
     }
     
-
+    
     
     /**
      *showTime* hides the notification bar after given time period.
@@ -136,12 +154,12 @@ public class GLNotificationBar: NSObject {
      
      - Returns: No return value.
      */
-
-    @objc public func showTime(timeInSec: Double){
+    
+    @objc open func showTime(_ timeInSec: Double){
         SHOW_TIME = timeInSec
     }
-
-
+    
+    
     
     /**
      *notificationSound* helps in playing the sound file while displaying notification, If file name or type does't found.Default sound will be played.
@@ -154,20 +172,20 @@ public class GLNotificationBar: NSObject {
      
      - Returns: No return value.
      */
-    @objc public func notificationSound(name: String!, ofType:String!, vibrate:Bool){
-
+    @objc open func notificationSound(_ name: String!, ofType:String!, vibrate:Bool){
+        
         if vibrate {
             AudioServicesPlayAlertSound(kSystemSoundID_Vibrate);
         }
-        guard let path = NSBundle.mainBundle().pathForResource(name, ofType: ofType) else {
+        guard let path = Bundle.main.path(forResource: name, ofType: ofType) else {
             NSLog("\n#NOTE: File name or type does't found.Default sound will be played.\n")
             AudioServicesPlaySystemSound(1054);
             return
         }
-        let pianoSound  =  NSURL(fileURLWithPath:path)
-       
+        let pianoSound  =  URL(fileURLWithPath:path)
+        
         do {
-            audioPlayer = try AVAudioPlayer(contentsOfURL: pianoSound, fileTypeHint: nil)
+            audioPlayer = try AVAudioPlayer(contentsOf: pianoSound, fileTypeHint: nil)
             audioPlayer.prepareToPlay()
             audioPlayer.play()
         } catch  {
@@ -176,23 +194,23 @@ public class GLNotificationBar: NSObject {
         }
         
     }
-
+    
     /**
      `addAction` helps in adding `GLNotifyAction` to notification bar as options to respond notification.
      
      - Parameter action:   add's `GLNotifyAction` object as action which including the title to display in the button, button style , and a handler to execute when the user taps the button
-
+     
      - Returns: No return value.
      */
     
-    @objc public func addAction(action: GLNotifyAction){
+    @objc open func addAction(_ action: GLNotifyAction){
         actionArray.append(action)    //Action for notification didselect
     }
-
-    @IBAction func hideNotification(sender:UIButton) {
+    
+    @IBAction func hideNotification(_ sender:UIButton) {
         if (notificationBar != nil) {
-            UIView.animateWithDuration(0.5, animations: {
-                notificationBar.frame.origin = CGPointMake(0, -BAR_HEIGHT)
+            UIView.animate(withDuration: 0.5, animations: {
+                notificationBar.frame.origin = CGPoint(x: 0, y: -BAR_HEIGHT)
                 }, completion: { (yes) in
                     notificationBar.removeFromSuperview()
                     APP_DELEGATE.keyWindow?.windowLevel = 0.0
@@ -201,7 +219,7 @@ public class GLNotificationBar: NSObject {
     }
     
     
-    private func setUpNotificationBar(header:String!, body:String!, notificationStyle:GLNotificationStyle) {
+    fileprivate func setUpNotificationBar(_ header:String!, body:String!, notificationStyle:GLNotificationStyle) {
         
         for subView in (APP_DELEGATE.keyWindow?.subviews)! {     //To clear old notification from queue
             if subView is CustomView {
@@ -209,42 +227,39 @@ public class GLNotificationBar: NSObject {
             }
         }
         
-        notificationBar = CustomView(frame: CGRectMake(0, -BAR_HEIGHT, frameWidth!, BAR_HEIGHT))
+        notificationBar = CustomView(frame: CGRect(x: 0, y: -BAR_HEIGHT, width: frameWidth!, height: BAR_HEIGHT))
         notificationBar.translatesAutoresizingMaskIntoConstraints = false
-
+        
         switch notificationStyle {
-        case .DetailedBanner:
-            notificationBar.notificationStyleIndicator.hidden = false
+        case .detailedBanner:
+            notificationBar.notificationStyleIndicator.isHidden = false
             showNotificationInDetail = true
             break
         default:
-            notificationBar.notificationStyleIndicator.hidden = true
+            notificationBar.notificationStyleIndicator.isHidden = true
             showNotificationInDetail = false
             break
         }
         
-        if header.characters.count == 0 {
-            notificationBar.body.text = body
-        }else{
-            let attributeString = NSMutableAttributedString(string: String("\(header)\n\(body)"))
-            attributeString.addAttributes([NSFontAttributeName:UIFont.boldSystemFontOfSize(15)], range: NSRange(location: 0, length: header.characters.count))
-            notificationBar.body.attributedText = attributeString
-        }
-
-        var infoDic:Dictionary = NSBundle.mainBundle().infoDictionary!
+        let attributeString = NSMutableAttributedString(string: String("\(header)\n\(body)"))
+        attributeString.addAttributes([NSFontAttributeName:UIFont.boldSystemFont(ofSize: 15)], range: NSRange(location: 0, length: header.characters.count))
+        notificationBar.body.attributedText = attributeString
+        
+        
+        var infoDic:Dictionary = Bundle.main.infoDictionary!
         appName = infoDic["CFBundleName"] as? String
         notificationBar.header.text = appName
         
         if infoDic["CFBundleIcons"] != nil {
             infoDic = infoDic["CFBundleIcons"] as! Dictionary
             infoDic = infoDic["CFBundlePrimaryIcon"] as! Dictionary
-            appIconName = infoDic["CFBundleIconFiles"]!.objectAtIndex(0) as! String
+            appIconName = (infoDic["CFBundleIconFiles"]! as AnyObject).object(at: 0) as! String
             notificationBar.appIcon.image = UIImage(named: appIconName)
             
         } else {
-            notificationBar.appIcon.layer.borderColor = UIColor.grayColor().CGColor
+            notificationBar.appIcon.layer.borderColor = UIColor.gray.cgColor
             notificationBar.appIcon.layer.borderWidth = 1.0
-
+            
             appIconName = ""
             print("Oops... no app icon found")
         }
@@ -260,8 +275,8 @@ public class GLNotificationBar: NSObject {
         let didSelectMessage = UITapGestureRecognizer(target: self, action: #selector(CustomView.didSelectmessage(_:)))
         notificationBar.addGestureRecognizer(didSelectMessage)
         
-        UIView.animateWithDuration(0.5, delay: 0.0, options: .CurveEaseOut, animations: { 
-            let frame = CGRectMake(0, 0, frameWidth, BAR_HEIGHT)
+        UIView.animate(withDuration: 0.5, delay: 0.0, options: .curveEaseOut, animations: {
+            let frame = CGRect(x: 0, y: 0, width: frameWidth, height: BAR_HEIGHT)
             notificationBar.frame = frame
             }, completion: nil)
         
@@ -270,32 +285,32 @@ public class GLNotificationBar: NSObject {
         
         var constraints = [NSLayoutConstraint]()
         
-        let horizontal = NSLayoutConstraint.constraintsWithVisualFormat("H:|[view]|", options: [], metrics: nil, views: ["view":notificationBar])
+        let horizontal = NSLayoutConstraint.constraints(withVisualFormat: "H:|[view]|", options: [], metrics: nil, views: ["view":notificationBar])
         constraints += horizontal
         
-        let vertical = NSLayoutConstraint.constraintsWithVisualFormat("V:|[view(100)]", options: [], metrics: nil, views: ["view":notificationBar])
+        let vertical = NSLayoutConstraint.constraints(withVisualFormat: "V:|[view(100)]", options: [], metrics: nil, views: ["view":notificationBar])
         constraints += vertical
         
-        NSLayoutConstraint.activateConstraints(constraints)
+        NSLayoutConstraint.activate(constraints)
         
     }
 }
 
 /**
-  A GLNotifyAction object represents an action that can be taken when tapping a button in an `GLNotificationBar`. You use this class to configure information about a single action, including the title to display in the button, any styling information, and a handler to execute when the user taps the button. After creating an notificatio action object, add it to a `GLNotificationBar` object before displaying the corresponding notification to the user.
+ A GLNotifyAction object represents an action that can be taken when tapping a button in an `GLNotificationBar`. You use this class to configure information about a single action, including the title to display in the button, any styling information, and a handler to execute when the user taps the button. After creating an notificatio action object, add it to a `GLNotificationBar` object before displaying the corresponding notification to the user.
  */
 
-public class GLNotifyAction : NSObject {
-    @objc public var actionTitle:String!
-    @objc public var textResponse:String!
-    @objc public var actionStyle:GLNotificationActionType = .Default
-    var didSelectAction:(GLNotifyAction -> Void)?
-
+open class GLNotifyAction : NSObject {
+    @objc open var actionTitle:String!
+    @objc open var textResponse:String!
+    @objc open var actionStyle:GLNotificationActionType = .default
+    var didSelectAction:((GLNotifyAction) -> Void)?
+    
     @objc public override init() {
         super.init()
     }
-
-
+    
+    
     /**
      Init a notification action and add it as action to `GLNotificationBar`.
      
@@ -312,12 +327,12 @@ public class GLNotifyAction : NSObject {
         actionTitle = title
         actionStyle = style
         didSelectAction = handler
-     }
+    }
 }
 
 class CustomView : UIView {
     //MARK: Outlets:
-    @IBOutlet private var view:UIView?
+    @IBOutlet fileprivate var view:UIView?
     @IBOutlet weak var header: UILabel!
     @IBOutlet weak var body: UILabel!
     @IBOutlet weak var visualEffectView: UIVisualEffectView!
@@ -327,7 +342,7 @@ class CustomView : UIView {
     //MARK: Variables:
     var dismissLabelAlpha:CGFloat = 0.0
     var dismissLimitReached = false
-
+    
     var toolBarBottomConstraint: NSLayoutConstraint?
     
     //MARK: Constants:
@@ -351,31 +366,31 @@ class CustomView : UIView {
         //self.commonInit()
     }
     
-    private func commonInit() {
-        NSBundle(forClass: CustomView.self)
+    fileprivate func commonInit() {
+        Bundle(for: CustomView.self)
             .loadNibNamed("GLNotificationBar", owner:self, options:nil)
-//        NSBundle.mainBundle().loadNibNamed("GLNotificationBar", owner: self, options: nil)
+        //        NSBundle.mainBundle().loadNibNamed("GLNotificationBar", owner: self, options: nil)
         guard let content = view else { return }
         content.frame = self.bounds
-        content.autoresizingMask = [.FlexibleHeight, .FlexibleWidth]
+        content.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         self.addSubview(content)
         
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(CustomView.keyboardWillShown(_:)), name: UIKeyboardWillShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(CustomView.keyboardWillHide(_:)), name: UIKeyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(CustomView.keyboardWillShown(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(CustomView.keyboardWillHide(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
         
     }
-
-
+    
+    
     //MARK: Open in detail:
-    func setUpDetailedNotificationBar(header:String!,body:String!,action:[GLNotifyAction]!) {
+    func setUpDetailedNotificationBar(_ header:String!,body:String!,action:[GLNotifyAction]!) {
         notificationStyleIndicator.layer.cornerRadius = 3.0
         notificationStyleIndicator.alpha = 0.5
         
         //Blurry Back ground
         let tapGesture = UIPanGestureRecognizer(target: self, action: #selector(CustomView.didSelectmessage(_:)))
         backgroudView.addGestureRecognizer(tapGesture)
-        backgroudView.effect = UIBlurEffect(style: .Dark)
-        backgroudView.autoresizingMask = [.FlexibleWidth,.FlexibleHeight] // support for device rotation
+        backgroudView.effect = UIBlurEffect(style: .dark)
+        backgroudView.autoresizingMask = [.flexibleWidth,.flexibleHeight] // support for device rotation
         backgroudView.translatesAutoresizingMaskIntoConstraints = false
         
         let tapToClose = UITapGestureRecognizer(target: self, action: #selector(CustomView.tapToClose(_:)))
@@ -383,13 +398,13 @@ class CustomView : UIView {
         backgroudView.addGestureRecognizer(tapToClose)
         //Main_View containing message banner and buttonAction.
         
-        mainView.backgroundColor = UIColor.clearColor()
+        mainView.backgroundColor = UIColor.clear
         mainView.translatesAutoresizingMaskIntoConstraints = false
-
+        
         //Notification Banner
         let detailedbanner = UIView()
         detailedbanner.translatesAutoresizingMaskIntoConstraints = false
-        detailedbanner.backgroundColor = UIColor.whiteColor()
+        detailedbanner.backgroundColor = UIColor.white
         detailedbanner.layer.cornerRadius = 14.0
         detailedbanner.clipsToBounds = true
         
@@ -406,9 +421,9 @@ class CustomView : UIView {
         
         dismissLabel.translatesAutoresizingMaskIntoConstraints = false
         dismissLabel.text = "DISMISS"
-        dismissLabel.textAlignment = NSTextAlignment.Center
-        dismissLabel.textColor = UIColor.whiteColor()
-        dismissLabel.font = UIFont.systemFontOfSize(14)
+        dismissLabel.textAlignment = NSTextAlignment.center
+        dismissLabel.textColor = UIColor.white
+        dismissLabel.font = UIFont.systemFont(ofSize: 14)
         dismissLabel.alpha = 0.0
         mainView.addSubview(dismissLabel)
         
@@ -417,38 +432,34 @@ class CustomView : UIView {
         let title = UILabel()
         title.translatesAutoresizingMaskIntoConstraints = false
         title.text = appName
-        title.backgroundColor = UIColor.clearColor()
-        title.textColor = UIColor.grayColor()
-        title.font = UIFont.systemFontOfSize(14)
+        title.backgroundColor = UIColor.clear
+        title.textColor = UIColor.gray
+        title.font = UIFont.systemFont(ofSize: 14)
         detailedbanner.addSubview(title)
         
         //Message body
-        let tempContainer = body.componentsSeparatedByString("\n")
+        let tempContainer = body.components(separatedBy: "\n")
         let rangeStr = tempContainer[0]
         let attributeString = NSMutableAttributedString(string: body)
-        if body.containsString("\n") {
-            attributeString.addAttributes([NSFontAttributeName:UIFont.boldSystemFontOfSize(15)], range: NSRange(location: 0, length: rangeStr.characters.count))
-            attributeString.addAttributes([NSFontAttributeName:UIFont.systemFontOfSize(15)], range: NSRange(location: rangeStr.characters.count, length: tempContainer[1].characters.count))
-        }else{
-            attributeString.addAttributes([NSFontAttributeName:UIFont.systemFontOfSize(15)], range: NSRange(location: 0, length: body.characters.count))
-        }
+        attributeString.addAttributes([NSFontAttributeName:UIFont.boldSystemFont(ofSize: 15)], range: NSRange(location: 0, length: rangeStr.characters.count))
+        attributeString.addAttributes([NSFontAttributeName:UIFont.systemFont(ofSize: 15)], range: NSRange(location: rangeStr.characters.count, length: tempContainer[1].characters.count))
         
         notificationMessage.translatesAutoresizingMaskIntoConstraints = false
-        notificationMessage.font = UIFont.systemFontOfSize(25)
-        notificationMessage.backgroundColor = UIColor.clearColor()
-        notificationMessage.textColor = UIColor.blackColor()
+        notificationMessage.font = UIFont.systemFont(ofSize: 25)
+        notificationMessage.backgroundColor = UIColor.clear
+        notificationMessage.textColor = UIColor.black
         notificationMessage.showsHorizontalScrollIndicator = false
-        notificationMessage.scrollEnabled = false
-        notificationMessage.editable = false
+        notificationMessage.isScrollEnabled = false
+        notificationMessage.isEditable = false
         notificationMessage.attributedText = attributeString
         
         
         detailedbanner.addSubview(notificationMessage)
-       
+        
         
         //Separator Line
         let seprator = UIView()
-        seprator.backgroundColor = UIColor.lightGrayColor()
+        seprator.backgroundColor = UIColor.lightGray
         seprator.translatesAutoresizingMaskIntoConstraints = false
         detailedbanner .addSubview(seprator)
         
@@ -457,7 +468,7 @@ class CustomView : UIView {
         if appIconName.characters.count != 0 {
             appIcon.image = UIImage(named: appIconName)
         }else{
-            appIcon.layer.borderColor = UIColor.grayColor().CGColor
+            appIcon.layer.borderColor = UIColor.gray.cgColor
             appIcon.layer.borderWidth = 1.0
         }
         
@@ -468,49 +479,49 @@ class CustomView : UIView {
         
         //Close Button
         let closeButton = UIButton()
-        closeButton.setImage(UIImage(named:"Close.png" ), forState: UIControlState.Normal)
-        closeButton.addTarget(self, action: #selector(CustomView.closeMessage(_:)), forControlEvents: UIControlEvents.TouchUpInside)
+        closeButton.setImage(UIImage(named:"Close" ), for: UIControlState())
+        closeButton.addTarget(self, action: #selector(CustomView.closeMessage(_:)), for: UIControlEvents.touchUpInside)
         closeButton.translatesAutoresizingMaskIntoConstraints = false
         detailedbanner.addSubview(closeButton)
         
         
-        UIApplication.sharedApplication().keyWindow!.addSubview(backgroudView)
+        UIApplication.shared.keyWindow!.addSubview(backgroudView)
         
         toolBar.translatesAutoresizingMaskIntoConstraints = false
-        toolBar.hidden = true
+        toolBar.isHidden = true
         backgroudView.addSubview(toolBar)
         
         //Adding autolayout
         
         addAutoLayout(["visualEffectView":backgroudView,"Main_view":mainView,"host_View" : detailedbanner,"Button_actionView":createNotificationActionView(),"container_Label":notificationMessage,"header_Label":title,"separator":seprator, "app_Icon":appIcon,"close_Button":closeButton,"Dismiss":dismissLabel,"Tool_Bar":toolBar])
         
-        self.mainView.transform = CGAffineTransformScale(CGAffineTransformIdentity, 0.0, 0.0)
-        UIView.animateWithDuration(0.3/1.5, delay: 0.0, options: .CurveEaseOut, animations: {
-            self.mainView.transform = CGAffineTransformScale(CGAffineTransformIdentity, 1.1, 1.1)
+        self.mainView.transform = CGAffineTransform.identity.scaledBy(x: 0.0, y: 0.0)
+        UIView.animate(withDuration: 0.3/1.5, delay: 0.0, options: .curveEaseOut, animations: {
+            self.mainView.transform = CGAffineTransform.identity.scaledBy(x: 1.1, y: 1.1)
         }) { (bool) in
-            UIView.animateWithDuration(0.3/2, delay: 0.0, options: .CurveEaseIn, animations: {
-                self.mainView.transform = CGAffineTransformIdentity
-            },completion:nil)
-         }
+            UIView.animate(withDuration: 0.3/2, delay: 0.0, options: .curveEaseIn, animations: {
+                self.mainView.transform = CGAffineTransform.identity
+                },completion:nil)
+        }
         
     }
-
+    
     func createNotificationActionView() -> UIVisualEffectView  {
         sortActionArray()  //sort button action on condition
         
         notificationActionView.translatesAutoresizingMaskIntoConstraints = false
-        notificationActionView.effect = UIBlurEffect(style: .ExtraLight)
+        notificationActionView.effect = UIBlurEffect(style: .extraLight)
         notificationActionView.layer.cornerRadius = 14.0
         notificationActionView.clipsToBounds = true
         mainView.addSubview(notificationActionView)
         
         let tableView = UITableView()
-        tableView.backgroundColor = UIColor.clearColor()
+        tableView.backgroundColor = UIColor.clear
         tableView.dataSource = self
         tableView.delegate = self
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.showsVerticalScrollIndicator = false
-        tableView.separatorStyle = .None
+        tableView.separatorStyle = .none
         notificationActionView.addSubview(tableView)
         
         var height = "0"
@@ -518,86 +529,86 @@ class CustomView : UIView {
         tempLabel.text = notificationMessage.text!
         let test = CGFloat(actionArray.count * 50) + tempLabel.heightToFit(notificationMessage.text!, width: (APP_DELEGATE.keyWindow?.frame.size.width)!)
         if test > APP_DELEGATE.keyWindow!.frame.size.height - 50 {
-            tableView.scrollEnabled = actionArray.count > 4 ? true : false
-            notificationMessage.scrollEnabled = true
+            tableView.isScrollEnabled = actionArray.count > 4 ? true : false
+            notificationMessage.isScrollEnabled = true
             height = actionArray.count > 4 ? "200" : String(actionArray.count * 50)
         }else{
-            tableView.scrollEnabled = false
+            tableView.isScrollEnabled = false
             height = String(actionArray.count * 50)
         }
         
         
         var constraints = [NSLayoutConstraint]()
-        let scrollHorizontalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("H:|[table]|", options: [], metrics: nil, views: ["table":tableView])
+        let scrollHorizontalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "H:|[table]|", options: [], metrics: nil, views: ["table":tableView])
         constraints += scrollHorizontalConstraint
         
-        let scrollVerticalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("V:|[table(h)]|", options: [], metrics: ["h":height], views: ["table":tableView])
+        let scrollVerticalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "V:|[table(h)]|", options: [], metrics: ["h":height], views: ["table":tableView])
         constraints += scrollVerticalConstraint
         
-        NSLayoutConstraint.activateConstraints(constraints)
+        NSLayoutConstraint.activate(constraints)
         
         return notificationActionView
     }
     
-    func addSeprator(toObject:AnyObject) -> UIView{
+    func addSeprator(_ toObject:AnyObject) -> UIView{
         let frame = toObject.frame
-        let seprator = UIView(frame: CGRectMake(0,frame.height + 3, (APP_DELEGATE.keyWindow?.frame.size.width)! - 20,0.5))
-        seprator.backgroundColor = UIColor.grayColor()
+        let seprator = UIView(frame: CGRect(x: 0,y: (frame?.height)! + 3, width: (APP_DELEGATE.keyWindow?.frame.size.width)! - 20,height: 0.5))
+        seprator.backgroundColor = UIColor.gray
         seprator.alpha = 0.6
         return seprator
     }
     
     //MARK: AutoLayout Constraints
-    func addAutoLayout(viewDic:[String:AnyObject]) {
+    func addAutoLayout(_ viewDic:[String:AnyObject]) {
         
         var allConstraints = [NSLayoutConstraint]()
         
         //Object Horizontal layout
-        let visualEffectHorizontal = NSLayoutConstraint.constraintsWithVisualFormat("H:|[visualEffectView]|", options: [], metrics: nil, views: viewDic)
+        let visualEffectHorizontal = NSLayoutConstraint.constraints(withVisualFormat: "H:|[visualEffectView]|", options: [], metrics: nil, views: viewDic)
         allConstraints += visualEffectHorizontal
         
-        let mainHorizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|[Main_view]|", options: [], metrics: nil, views: viewDic)
+        let mainHorizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|[Main_view]|", options: [], metrics: nil, views: viewDic)
         allConstraints += mainHorizontalConstraints
         
         
-        let hostHorizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-[host_View]-|", options: [], metrics: nil, views: viewDic)
+        let hostHorizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|-[host_View]-|", options: [], metrics: nil, views: viewDic)
         allConstraints += hostHorizontalConstraints
         
         
-        let actionHorizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-[Button_actionView]-|", options: [], metrics: nil, views: viewDic)
+        let actionHorizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|-[Button_actionView]-|", options: [], metrics: nil, views: viewDic)
         allConstraints += actionHorizontalConstraints
         
-        let dismissHorizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-15-[Dismiss]-15-|", options: [], metrics: nil, views: viewDic)
+        let dismissHorizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|-15-[Dismiss]-15-|", options: [], metrics: nil, views: viewDic)
         allConstraints += dismissHorizontalConstraints
         
-        let headerHorizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-10-[app_Icon(20)]-10-[header_Label]-10-[close_Button(30)]-10-|", options: [], metrics: nil, views: viewDic)
+        let headerHorizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|-10-[app_Icon(20)]-10-[header_Label]-10-[close_Button(30)]-10-|", options: [], metrics: nil, views: viewDic)
         allConstraints += headerHorizontalConstraints
         
         
-        let separatorHorizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-[separator]-|", options: [], metrics: nil, views: viewDic)
+        let separatorHorizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|-[separator]-|", options: [], metrics: nil, views: viewDic)
         allConstraints += separatorHorizontalConstraints
         
-        let labelHorizontalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("H:|-15-[container_Label]-15-|", options: [], metrics: nil, views: viewDic)
+        let labelHorizontalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "H:|-15-[container_Label]-15-|", options: [], metrics: nil, views: viewDic)
         allConstraints += labelHorizontalConstraints
         
-        let textInputHorizontalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("H:|[Tool_Bar]|", options: [], metrics: nil, views: viewDic)
+        let textInputHorizontalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "H:|[Tool_Bar]|", options: [], metrics: nil, views: viewDic)
         allConstraints += textInputHorizontalConstraint
         
         //Object Vertical layout
         
-        let visualEffectVertical = NSLayoutConstraint.constraintsWithVisualFormat("V:|[visualEffectView]|", options: [], metrics: nil, views: viewDic)
+        let visualEffectVertical = NSLayoutConstraint.constraints(withVisualFormat: "V:|[visualEffectView]|", options: [], metrics: nil, views: viewDic)
         allConstraints += visualEffectVertical
         
-        let main1VerticalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[Main_view]-(>=10)-|", options: [], metrics: nil, views: viewDic)
+        let main1VerticalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "V:|[Main_view]-(>=10)-|", options: [], metrics: nil, views: viewDic)
         allConstraints += main1VerticalConstraints
         
-        let mainVerticalConstraints = NSLayoutConstraint.constraintsWithVisualFormat("V:|[Main_view(200@250)]-(>=5)-[Tool_Bar]-(0@250)-|", options: [], metrics: nil, views: viewDic)
+        let mainVerticalConstraints = NSLayoutConstraint.constraints(withVisualFormat: "V:|[Main_view(200@250)]-(>=5)-[Tool_Bar]-(0@250)-|", options: [], metrics: nil, views: viewDic)
         allConstraints += mainVerticalConstraints
         
-        let hostVerticalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("V:|[Dismiss]-[host_View(>=20)]-10-[Button_actionView(>=0)]-(>=10)-|", options: [], metrics: nil, views: viewDic)
+        let hostVerticalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "V:|[Dismiss]-[host_View(>=20)]-10-[Button_actionView(>=0)]-(>=10)-|", options: [], metrics: nil, views: viewDic)
         allConstraints += hostVerticalConstraint
         
-        let hostSecondVerticalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("V:[host_View]-(>=30)-|", options: [], metrics: nil, views: viewDic)
+        let hostSecondVerticalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "V:[host_View]-(>=30)-|", options: [], metrics: nil, views: viewDic)
         allConstraints += hostSecondVerticalConstraint
         
         let tempLabel = UILabel()
@@ -605,13 +616,13 @@ class CustomView : UIView {
         let expectedContentheight = CGFloat(actionArray.count * 50) + tempLabel.heightToFit(tempLabel.text!, width: (APP_DELEGATE.keyWindow?.frame.size.width)!)
         var messageHeight = ""
         if expectedContentheight > APP_DELEGATE.keyWindow!.frame.size.height - 50 {
-            messageHeight = String(APP_DELEGATE.keyWindow!.frame.size.height - CGFloat(actionArray.count < 4 ? actionArray.count * 50 : 200))
+            messageHeight = String(describing: APP_DELEGATE.keyWindow!.frame.size.height - CGFloat(actionArray.count < 4 ? actionArray.count * 50 : 200))
         }
         if messageHeight.characters.count > 0 {
-            let verticalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("V:|-15-[header_Label(20)]-[separator(1)]-[container_Label(h@750)]-(>=5)-|", options: [], metrics: ["h":messageHeight], views: viewDic)
+            let verticalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "V:|-15-[header_Label(20)]-[separator(1)]-[container_Label(h@750)]-(>=5)-|", options: [], metrics: ["h":messageHeight], views: viewDic)
             allConstraints += verticalConstraint
         }else{
-            let verticalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("V:|-15-[header_Label(20)]-[separator(1)]-[container_Label(30@250)]-(>=5)-|", options: [], metrics: nil, views: viewDic)
+            let verticalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "V:|-15-[header_Label(20)]-[separator(1)]-[container_Label(30@250)]-(>=5)-|", options: [], metrics: nil, views: viewDic)
             allConstraints += verticalConstraint
         }
         
@@ -619,50 +630,51 @@ class CustomView : UIView {
         /*let verticalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("V:|-15-[header_Label(20)]-[separator(1)]-[container_Label(30@250)]-(>=5)-|", options: [], metrics: nil, views: viewDic)
          allConstraints += verticalConstraint*/
         
-        let appIconVerticalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("V:|-15-[app_Icon(20)]", options: [], metrics: nil, views: viewDic)
+        let appIconVerticalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "V:|-15-[app_Icon(20)]", options: [], metrics: nil, views: viewDic)
         allConstraints += appIconVerticalConstraint
         
-        let closeVerticalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("V:|-15-[close_Button(20)]", options: [], metrics: nil, views: viewDic)
+        let closeVerticalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "V:|-15-[close_Button(20)]", options: [], metrics: nil, views: viewDic)
         allConstraints += closeVerticalConstraint
         
-        NSLayoutConstraint.activateConstraints(allConstraints)
+        NSLayoutConstraint.activate(allConstraints)
     }
     
     
-
+    
     //MARK: GestureRecognizer:
-    @IBAction func didSelectmessage(tapgesture: UITapGestureRecognizer) {
+    @IBAction func didSelectmessage(_ tapgesture: UITapGestureRecognizer) {
         if (notificationBar != nil) {
-            UIView.animateWithDuration(0.5, animations: {
-                notificationBar.frame.origin = CGPointMake(0, -BAR_HEIGHT)
+            UIView.animate(withDuration: 0.5, animations: {
+                notificationBar.frame.origin = CGPoint(x: 0, y: -BAR_HEIGHT)
                 }, completion: { (yes) in
                     notificationBar.removeFromSuperview()
+                    APP_DELEGATE.keyWindow?.windowLevel = 0.0
             })
         }
         closeMessage(nil)
         messageDidSelect(true)
     }
     
-    @IBAction func tapToClose(tapgesture: UITapGestureRecognizer) {
+    @IBAction func tapToClose(_ tapgesture: UITapGestureRecognizer) {
         closeMessage(nil)
     }
     
     
-    @IBAction func panGesture(gestureRecognizer: UIPanGestureRecognizer) {
-        let velocity = gestureRecognizer.velocityInView(self)
-        let translation = gestureRecognizer.translationInView(self)
+    @IBAction func panGesture(_ gestureRecognizer: UIPanGestureRecognizer) {
+        let velocity = gestureRecognizer.velocity(in: self)
+        let translation = gestureRecognizer.translation(in: self)
         
         switch gestureRecognizer.state {
-        case .Began,.Changed:
+        case .began,.changed:
             let directionValue =  velocity.y < 1.0 ? -1 : 1
             
             switch directionValue {
-            case PanDirection.Up.rawValue:  //Swipe up
-                gestureRecognizer.view!.center = CGPointMake(gestureRecognizer.view!.center.x, gestureRecognizer.view!.center.y + translation.y)
+            case PanDirection.up.rawValue:  //Swipe up
+                gestureRecognizer.view!.center = CGPoint(x: gestureRecognizer.view!.center.x, y: gestureRecognizer.view!.center.y + translation.y)
                 break
-            case PanDirection.Down.rawValue:  //Swipe Down
+            case PanDirection.down.rawValue:  //Swipe Down
                 if showNotificationInDetail {
-                    gestureRecognizer.view!.center = CGPointMake(gestureRecognizer.view!.center.x, gestureRecognizer.view!.center.y + translation.y)
+                    gestureRecognizer.view!.center = CGPoint(x: gestureRecognizer.view!.center.x, y: gestureRecognizer.view!.center.y + translation.y)
                 }
                 break
             default:
@@ -670,7 +682,7 @@ class CustomView : UIView {
             }
             
             
-            gestureRecognizer.setTranslation(CGPointMake(0,0), inView: self)
+            gestureRecognizer.setTranslation(CGPoint(x: 0,y: 0), in: self)
             
             if gestureRecognizer.view?.frame.origin.y  > (gestureRecognizer.view?.frame.size.height)! {
                 self.removeFromSuperview()
@@ -679,17 +691,16 @@ class CustomView : UIView {
             }
             
             break
-        case .Ended:
+        case .ended:
             
             if gestureRecognizer.view?.frame.origin.y  < -(self.visualEffectView.frame.origin.y) {
-                APP_DELEGATE.keyWindow?.windowLevel = 0.0
                 actionArray = [GLNotifyAction]()  //Clear cached action before leaving
                 self.removeFromSuperview()
                 return
             }
             
-            UIView.animateWithDuration(0.5, animations: {
-                gestureRecognizer.view?.frame.origin = CGPointMake(gestureRecognizer.view!.frame.origin.x, 10)
+            UIView.animate(withDuration: 0.5, animations: {
+                gestureRecognizer.view?.frame.origin = CGPoint(x: gestureRecognizer.view!.frame.origin.x, y: 10)
             })
             
             break
@@ -699,31 +710,31 @@ class CustomView : UIView {
         
     }
     
-    func handleDetailedPanGesture(panGesture: UIPanGestureRecognizer) {
+    func handleDetailedPanGesture(_ panGesture: UIPanGestureRecognizer) {
         
         var isLandScape = false
-        let translation = panGesture.translationInView(self)
-        let velocity = panGesture.velocityInView(self)
+        let translation = panGesture.translation(in: self)
+        let velocity = panGesture.velocity(in: self)
         var panVelocity:CGFloat!
         
-        panGesture.setTranslation(CGPointMake(0,0), inView: self)
+        panGesture.setTranslation(CGPoint(x: 0,y: 0), in: self)
         
         switch panGesture.state {
-        case .Changed, .Began:
+        case .changed, .began:
             let orientation = APP_DELEGATE.statusBarOrientation
             
             switch orientation {
-            case .Portrait:
-                mainView.center = CGPointMake(mainView.center.x, mainView.center.y + (translation.y / 5))
+            case .portrait:
+                mainView.center = CGPoint(x: mainView.center.x, y: mainView.center.y + (translation.y / 5))
                 panVelocity =  velocity.y
                 break
-            case .LandscapeLeft:
-                mainView.center = CGPointMake(mainView.center.x, mainView.center.y + (translation.x / 5))
+            case .landscapeLeft:
+                mainView.center = CGPoint(x: mainView.center.x, y: mainView.center.y + (translation.x / 5))
                 panVelocity =  velocity.x
                 isLandScape = true
                 break
-            case .LandscapeRight:
-                mainView.center =  CGPointMake(mainView.center.x, mainView.center.y + (-translation.x / 5))
+            case .landscapeRight:
+                mainView.center =  CGPoint(x: mainView.center.x, y: mainView.center.y + (-translation.x / 5))
                 panVelocity =  -velocity.x
                 isLandScape = true
                 break
@@ -734,7 +745,7 @@ class CustomView : UIView {
             let directionValue =  panVelocity < 1.0 ? -1 : 1
             
             switch directionValue {
-            case PanDirection.Up.rawValue:  //Swipe up
+            case PanDirection.up.rawValue:  //Swipe up
                 if dismissLabel.alpha > 0.0 {
                     dismissLabelAlpha -= isLandScape ? 0.05 : 0.02
                 }else if dismissLabel.alpha <= 1.0 && dismissLimitReached{
@@ -745,17 +756,17 @@ class CustomView : UIView {
                     dismissLabel.alpha = 0.0
                 }
                 break
-            case PanDirection.Down.rawValue:  //Swipe down
+            case PanDirection.down.rawValue:  //Swipe down
                 if dismissLabel.alpha < 1.0 {
                     dismissLabelAlpha += isLandScape ? 0.05 : 0.02
                 }else if dismissLabel.alpha >= 1.0 && !dismissLimitReached{
                     dismissLimitReached = true
-                    dismissLabel.transform = CGAffineTransformScale(CGAffineTransformIdentity, 0.0, 0.0)
-                    UIView.animateWithDuration(0.3/1.5, delay: 0.0, options: .CurveEaseInOut, animations: {
-                        self.dismissLabel.transform = CGAffineTransformScale(CGAffineTransformIdentity, 1.3, 1.3)
+                    dismissLabel.transform = CGAffineTransform.identity.scaledBy(x: 0.0, y: 0.0)
+                    UIView.animate(withDuration: 0.3/1.5, delay: 0.0, options: UIViewAnimationOptions(), animations: {
+                        self.dismissLabel.transform = CGAffineTransform.identity.scaledBy(x: 1.3, y: 1.3)
                     }) { (bool) in
-                        UIView.animateWithDuration(0.3/2, delay: 0.0, options: .CurveEaseIn, animations: {
-                            self.dismissLabel.transform = CGAffineTransformIdentity
+                        UIView.animate(withDuration: 0.3/2, delay: 0.0, options: .curveEaseIn, animations: {
+                            self.dismissLabel.transform = CGAffineTransform.identity
                             },completion:nil)
                     }
                 }
@@ -771,7 +782,7 @@ class CustomView : UIView {
             
             break
             
-        case .Ended:
+        case .ended:
             
             
             if dismissLimitReached {
@@ -779,8 +790,8 @@ class CustomView : UIView {
                 return
             }
             
-            UIView.animateWithDuration(0.5, animations: {
-                self.mainView.frame.origin = CGPointMake(0, 0)
+            UIView.animate(withDuration: 0.5, animations: {
+                self.mainView.frame.origin = CGPoint(x: 0, y: 0)
             })
             
             dismissLimitReached = false
@@ -793,7 +804,7 @@ class CustomView : UIView {
         }
     }
     
-
+    
     
     //MARK: Support:
     func sortActionArray() {
@@ -801,18 +812,18 @@ class CustomView : UIView {
         var index = 0
         var isCancelTypeFound = false
         for action in actionArray {
-
+            
             let style:GLNotificationActionType = action.actionStyle
             switch style{
-            case .Cancel:
-                actionArray.removeAtIndex(index)
+            case .cancel:
+                actionArray.remove(at: index)
                 index = index - 1
                 if !isCancelTypeFound {
                     isCancelTypeFound = true
                     tempContainer.append(action)
                 }
                 break
-            case .OnlyTextInput:
+            case .onlyTextInput:
                 setUpTextField(action, senderTag: index)
                 continue
             default:
@@ -822,91 +833,91 @@ class CustomView : UIView {
         }
         if tempContainer.count != 0 {
             actionArray.append(tempContainer[0])
-//            print("\n\n#WARNING: Only one .Cancel type can be added to GLNotifyAction.Others will be not taken into account \n")
+            //            print("\n\n#WARNING: Only one .Cancel type can be added to GLNotifyAction.Others will be not taken into account \n")
         }
     }
     
-    func imageWithColor(color:UIColor) -> UIImage {
-        let rect = CGRectMake(0.0, 0.0, 1.0, 1.0)
+    func imageWithColor(_ color:UIColor) -> UIImage {
+        let rect = CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0)
         UIGraphicsBeginImageContext(rect.size);
         let context = UIGraphicsGetCurrentContext()
-        CGContextSetFillColorWithColor(context, color.CGColor)
-        CGContextFillRect(context, rect)
+        context?.setFillColor(color.cgColor)
+        context?.fill(rect)
         
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         
-        return image
+        return image!
     }
-
     
     
-    func setUpTextField(action:GLNotifyAction, senderTag:Int)  {
+    
+    func setUpTextField(_ action:GLNotifyAction, senderTag:Int)  {
         
-        UIView.animateWithDuration(1.0, animations: {
-            self.notificationActionView.hidden = true
-        }) { (bool) in
-            self.notificationActionView.removeFromSuperview()
-        }
+        UIView.animate(withDuration: 1.0, animations: {
+            self.notificationActionView.isHidden = true
+            }, completion: { (bool) in
+                self.notificationActionView.removeFromSuperview()
+        })
         
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.placeholder = action.actionTitle
-        textField.font = UIFont.systemFontOfSize(14)
-        textField.borderStyle = UITextBorderStyle.RoundedRect
+        textField.font = UIFont.systemFont(ofSize: 14)
+        textField.borderStyle = UITextBorderStyle.roundedRect
         
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("Send", forState: .Normal)
+        button.setTitle("Send", for: UIControlState())
         button.tag = senderTag
-        button.setTitleColor(UIColor.init(netHex: 0x095FFE), forState: .Normal)
-        button.titleLabel?.font = UIFont.systemFontOfSize(15)
-        button.addTarget(self, action: #selector(CustomView.sendButtonPressed(_:)), forControlEvents: .TouchUpInside)
+        button.setTitleColor(UIColor.init(netHex: 0x095FFE), for: UIControlState())
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 15)
+        button.addTarget(self, action: #selector(CustomView.sendButtonPressed(_:)), for: .touchUpInside)
         
         
         let barButtonItemOne = UIBarButtonItem(customView: textField)
         let barButtonItemtwo = UIBarButtonItem(customView: button)
         
-        toolBar.hidden = false
+        toolBar.isHidden = false
         toolBar.items = [barButtonItemOne,barButtonItemtwo]
         
         
         var constraints = [NSLayoutConstraint]()
         let dic = ["textField":textField,"button":button,"Main":toolBar];
         
-        let horizontalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("H:|-[textField][button(60)]|", options: [], metrics: nil, views: dic)
+        let horizontalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "H:|-[textField][button(60)]|", options: [], metrics: nil, views: dic)
         constraints += horizontalConstraint
         
-        let verticalConstraint = NSLayoutConstraint.constraintsWithVisualFormat("V:|-[textField(30)]-|", options: [], metrics: nil, views: dic)
+        let verticalConstraint = NSLayoutConstraint.constraints(withVisualFormat: "V:|-[textField(30)]-|", options: [], metrics: nil, views: dic)
         constraints += verticalConstraint
         
-        let verticalConstraint1 = NSLayoutConstraint.constraintsWithVisualFormat("V:|-[button]-|", options: [], metrics: nil, views: dic)
+        let verticalConstraint1 = NSLayoutConstraint.constraints(withVisualFormat: "V:|-[button]-|", options: [], metrics: nil, views: dic)
         constraints += verticalConstraint1
         
-//        let toolBarTopConstraint = NSLayoutConstraint.constraintsWithVisualFormat("V:[toolBar]-20-[MainView]", options: [], metrics: nil, views: ["toolBar":toolBar,"MainView":mainView])
-//        constraints += toolBarTopConstraint
+        //        let toolBarTopConstraint = NSLayoutConstraint.constraintsWithVisualFormat("V:[toolBar]-20-[MainView]", options: [], metrics: nil, views: ["toolBar":toolBar,"MainView":mainView])
+        //        constraints += toolBarTopConstraint
         
-        NSLayoutConstraint.activateConstraints(constraints)
+        NSLayoutConstraint.activate(constraints)
         
         
-        toolBarBottomConstraint = NSLayoutConstraint(item: toolBar, attribute: .Bottom, relatedBy: .Equal, toItem: backgroudView, attribute: .Bottom, multiplier: 1, constant: 0)
+        toolBarBottomConstraint = NSLayoutConstraint(item: toolBar, attribute: .bottom, relatedBy: .equal, toItem: backgroudView, attribute: .bottom, multiplier: 1, constant: 0)
         backgroudView.addConstraint(toolBarBottomConstraint!)
         
-        let leading = NSLayoutConstraint(item: toolBar, attribute: .Leading, relatedBy: .Equal, toItem: backgroudView, attribute: .Leading, multiplier: 1, constant: 0)
+        let leading = NSLayoutConstraint(item: toolBar, attribute: .leading, relatedBy: .equal, toItem: backgroudView, attribute: .leading, multiplier: 1, constant: 0)
         backgroudView.addConstraint(leading)
         
-        let trailing = NSLayoutConstraint(item: toolBar, attribute: .Trailing, relatedBy: .Equal, toItem: backgroudView, attribute: .Trailing, multiplier: 1, constant: 0)
+        let trailing = NSLayoutConstraint(item: toolBar, attribute: .trailing, relatedBy: .equal, toItem: backgroudView, attribute: .trailing, multiplier: 1, constant: 0)
         backgroudView.addConstraint(trailing)
         
-        let time = dispatch_time(DISPATCH_TIME_NOW, Int64(1.0 * Double(NSEC_PER_SEC) ))
-        dispatch_after(time, dispatch_get_main_queue()) {
+        let time = DispatchTime.now() + Double(Int64(1.0 * Double(NSEC_PER_SEC) )) / Double(NSEC_PER_SEC)
+        DispatchQueue.main.asyncAfter(deadline: time) {
             self.textField.becomeFirstResponder()
         }
         
     }
     
-
     
-    @IBAction func sendButtonPressed(sender:UIButton) {
+    
+    @IBAction func sendButtonPressed(_ sender:UIButton) {
         let action:GLNotifyAction = actionArray[sender.tag]
         guard let didselectHandler = action.didSelectAction else{
             closeMessage(sender)
@@ -917,28 +928,27 @@ class CustomView : UIView {
         closeMessage(sender)
     }
     
-
-    @IBAction func closeMessage(sender: UIButton?) {
+    
+    @IBAction func closeMessage(_ sender: UIButton?) {
         actionArray = [GLNotifyAction]()  //Clear cached action before leaving
         textField.resignFirstResponder()
-        APP_DELEGATE.keyWindow?.windowLevel = 0.0
-
-        UIView.animateWithDuration(0.5, animations: {
-            self.mainView.frame.origin = CGPointMake(0, (APP_DELEGATE.keyWindow?.frame.size.height)!)
-            }) { (ok) in
-                UIView.animateWithDuration(2.0, delay: 0.5, options: [], animations: {
+        
+        UIView.animate(withDuration: 0.5, animations: {
+            self.mainView.frame.origin = CGPoint(x: 0, y: (APP_DELEGATE.keyWindow?.frame.size.height)!)
+            }, completion: { (ok) in
+                UIView.animate(withDuration: 2.0, delay: 0.5, options: [], animations: {
                     self.backgroudView.removeFromSuperview()
                     }, completion: nil)
-        }
+        })
     }
     
     
     //MARK: Notification center:
-    func keyboardWillShown(notification: NSNotification) {
-        let info = notification.userInfo!
-        let keyboardFrame: CGRect = (info[UIKeyboardFrameEndUserInfoKey] as! NSValue).CGRectValue()
+    func keyboardWillShown(_ notification: Notification) {
+        let info = (notification as NSNotification).userInfo!
+        let keyboardFrame: CGRect = (info[UIKeyboardFrameEndUserInfoKey] as! NSValue).cgRectValue
         
-        UIView.animateWithDuration(0.1, animations: { () -> Void in
+        UIView.animate(withDuration: 0.1, animations: { () -> Void in
             if self.toolBarBottomConstraint != nil {
                 self.toolBarBottomConstraint!.constant = -(keyboardFrame.size.height)
                 self.backgroudView.layoutIfNeeded()
@@ -947,11 +957,11 @@ class CustomView : UIView {
         })
     }
     
-    func keyboardWillHide(notification: NSNotification) {
-        let info = notification.userInfo!
-        let keyboardFrame: CGRect = (info[UIKeyboardFrameEndUserInfoKey] as! NSValue).CGRectValue()
+    func keyboardWillHide(_ notification: Notification) {
+        let info = (notification as NSNotification).userInfo!
+        let keyboardFrame: CGRect = (info[UIKeyboardFrameEndUserInfoKey] as! NSValue).cgRectValue
         
-        UIView.animateWithDuration(0.1, animations: { () -> Void in
+        UIView.animate(withDuration: 0.1, animations: { () -> Void in
             if self.toolBarBottomConstraint != nil {
                 self.toolBarBottomConstraint!.constant = keyboardFrame.size.height
                 self.backgroudView.layoutIfNeeded()
@@ -959,13 +969,13 @@ class CustomView : UIView {
             
         })
     }
-
+    
 }
 
 //MARK: Extensions:
 extension CustomView: UIGestureRecognizerDelegate{
-    func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldReceiveTouch touch: UITouch) -> Bool {
-        if touch.view!.isDescendantOfView(notificationActionView) {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        if touch.view!.isDescendant(of: notificationActionView) {
             return false
         }
         return true
@@ -973,37 +983,37 @@ extension CustomView: UIGestureRecognizerDelegate{
 }
 
 extension CustomView : UITableViewDataSource,UITableViewDelegate{
-    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return actionArray.count
     }
     
-    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = UITableViewCell(style: .Default, reuseIdentifier: "GL")
-        cell.backgroundColor = UIColor.clearColor()
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: "GL")
+        cell.backgroundColor = UIColor.clear
         cell.drawSeparatorLine()
-        let action = actionArray[indexPath.row]
+        let action = actionArray[(indexPath as NSIndexPath).row]
         let style:GLNotificationActionType = action.actionStyle
         switch style{
-        case .Cancel:
-            cell.textLabel?.font = UIFont.boldSystemFontOfSize(20)
+        case .cancel:
+            cell.textLabel?.font = UIFont.boldSystemFont(ofSize: 20)
             break
-        case .Destructive:
-            cell.textLabel?.textColor = UIColor.redColor()
+        case .destructive:
+            cell.textLabel?.textColor = UIColor.red
             break
         default:
             break
         }
-        cell.textLabel?.text = actionArray[indexPath.row].actionTitle
-        cell.textLabel?.textAlignment = NSTextAlignment.Center
+        cell.textLabel?.text = actionArray[(indexPath as NSIndexPath).row].actionTitle
+        cell.textLabel?.textAlignment = NSTextAlignment.center
         return cell
     }
     
-    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        let action = actionArray[indexPath.row]
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let action = actionArray[(indexPath as NSIndexPath).row]
         let style:GLNotificationActionType = action.actionStyle
         switch style{
-        case .Cancel,.Destructive,.Default:
-            let action:GLNotifyAction = actionArray[indexPath.row]
+        case .cancel,.destructive,.default:
+            let action:GLNotifyAction = actionArray[(indexPath as NSIndexPath).row]
             guard let didselectHandler = action.didSelectAction else{
                 closeMessage(nil)
                 return
@@ -1011,15 +1021,15 @@ extension CustomView : UITableViewDataSource,UITableViewDelegate{
             didselectHandler(action)
             closeMessage(nil)
             break
-        case .TextInput:
-            self.setUpTextField(action,senderTag:indexPath.row)
+        case .textInput:
+            self.setUpTextField(action,senderTag:(indexPath as NSIndexPath).row)
             break
         default:
             break
         }
     }
-
-    func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 50
     }
 }
@@ -1027,7 +1037,7 @@ extension CustomView : UITableViewDataSource,UITableViewDelegate{
 extension UITableViewCell{
     func drawSeparatorLine() {
         let border = CALayer()
-        border.borderColor = UIColor.grayColor().CGColor
+        border.borderColor = UIColor.gray.cgColor
         border.frame = CGRect(x: 0, y: 49,
                               width: 0, height: 2)
         border.frame.size.width = (APP_DELEGATE.keyWindow?.frame.size.height > APP_DELEGATE.keyWindow?.frame.size.width ? APP_DELEGATE.keyWindow?.frame.size.height : APP_DELEGATE.keyWindow?.frame.size.width)!
@@ -1053,20 +1063,20 @@ extension UIColor {
 }
 
 extension UILabel {
-    func heightToFit(string:String,width:CGFloat) -> CGFloat{
+    func heightToFit(_ string:String,width:CGFloat) -> CGFloat{
         let attributes = [NSFontAttributeName : font]
         numberOfLines = 0
-        lineBreakMode = NSLineBreakMode.ByWordWrapping
-        let rect = string.boundingRectWithSize(CGSizeMake(width, CGFloat.max), options: NSStringDrawingOptions.UsesLineFragmentOrigin, attributes: attributes, context: nil)
+        lineBreakMode = NSLineBreakMode.byWordWrapping
+        let rect = string.boundingRect(with: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude), options: NSStringDrawingOptions.usesLineFragmentOrigin, attributes: attributes, context: nil)
         return rect.height
-//        self.frame.size.height = rect.height
+        //        self.frame.size.height = rect.height
     }
     
     func resizeHeightToFit() {
         let attributes = [NSFontAttributeName : font]
         numberOfLines = 0
-        lineBreakMode = NSLineBreakMode.ByWordWrapping
-        let rect = text!.boundingRectWithSize(CGSizeMake(frame.size.width, CGFloat.max), options: NSStringDrawingOptions.UsesLineFragmentOrigin, attributes: attributes, context: nil)
+        lineBreakMode = NSLineBreakMode.byWordWrapping
+        let rect = text!.boundingRect(with: CGSize(width: frame.size.width, height: CGFloat.greatestFiniteMagnitude), options: NSStringDrawingOptions.usesLineFragmentOrigin, attributes: attributes, context: nil)
         self.frame.size.height = rect.height
     }
 }


### PR DESCRIPTION
Now works with Swift 3 and the header and body are (safely) unwrapped, in case of nil are replaced with ""